### PR TITLE
Comment tempfile require

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   ameba:
     github: veelenga/ameba
-    version: 0.8.0
+    version: 0.8.1
 

--- a/src/coverage/inject/cli.cr
+++ b/src/coverage/inject/cli.cr
@@ -1,5 +1,5 @@
 require "option_parser"
-require "tempfile"
+# require "tempfile"
 
 module Coverage
   module CLI


### PR DESCRIPTION
Hi,

I commented on the "require 'tempfile'" which no longer serves.
I took advantage to test the build with crystal 0.27 and the new version of ameba