### PR TITLE
Replace unsafe_at with unsafe_fetch

### DIFF
--- a/src/coverage/runtime/coverage.cr
+++ b/src/coverage/runtime/coverage.cr
@@ -37,7 +37,7 @@ module Coverage
 
   @[AlwaysInline]
   def self.[](file_id, line_id)
-    @@files.unsafe_at(file_id)[line_id]
+    @@files.unsafe_fetch(file_id)[line_id]
   end
 
   # Return results of the coverage in JSON


### PR DESCRIPTION
Crystal 0.27.0 dropped `at` in favor of `fetch`. https://github.com/crystal-lang/crystal/commit/9d6fc90b71ca7d85c225b414dd4a7385a04bc13f specificly shows how. `fetch` is a drop-in replacement here.
Without this change, I cannot run the coverage on my app.