### PR TITLE
Change `epoch` to `to_unix` for Time.now

### DIFF
--- a/src/coverage/runtime/outputters/coveralls.cr
+++ b/src/coverage/runtime/outputters/coveralls.cr
@@ -1,6 +1,6 @@
 class Coverage::Outputter::Coveralls < Coverage::Outputter
   def initialize
-    @service_job_id = (ENV["TRAVIS_JOB_ID"]? || Time.now.epoch.to_s)
+    @service_job_id = (ENV["TRAVIS_JOB_ID"]? || Time.now.to_unix.to_s)
     @service_name = ENV["TRAVIS"]? ? "travis-ci" : "dev"
   end
 


### PR DESCRIPTION
This was a breaking change in crystal 0.27.0.
See https://crystal-lang.org/2018/11/01/crystal-0.27.0-released.html