### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+language: crystal
+
+crystal:
+  - latest
+  
+script:
+  - crystal spec spec/main.cr
+  - ./bin/ameba

--- a/README.md
+++ b/README.md
@@ -75,5 +75,4 @@ It then generate a report in the directory `/coverage/` relative to your project
 
 ## Planned features
 
-- Binding with travis + coveralls
-- 
+- Binding with coveralls


### PR DESCRIPTION
## Prerequisites

- [ ] Requires https://github.com/anykeyh/crystal-coverage/pull/8

---
- Adds a `.travis.yml` file that includes running the current test suite and `ameba`.

A repository administrator will need to finish adding this to TravisCI and requiring it on pull-requests.