### PR TITLE
update Ameba version to 0.10.0 (Crystal 0.29.0 compatible)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: crystal
+
+crystal:
+  - latest

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 1.0
 shards:
   ameba:
     github: veelenga/ameba
-    version: 0.8.1
+    version: 0.10.0
 


### PR DESCRIPTION
The repo is currently locked at Ameba 0.8.1, which is not Crystal 0.29.0 compatible. This PR updates the Ameba dependency.