### PR TITLE
Update to Crystal 1.0.0+ and better integrate with spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHARD_BIN ?= ../../bin
 
 build: bin/crystal-coverage
 bin/crystal-coverage: $(shell find src -type f -name '*.cr')
-	$(SHARDS_BIN) build $(CRFLAGS)
+	$(SHARDS_BIN) --without-development build $(CRFLAGS)
 clean:
 	rm -f .bin/crystal-coverage .bin/crystal-coverage.dwarf
 install: build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX ?= /usr/local
 SHARD_BIN ?= ../../bin
 
 build: bin/crystal-coverage
-bin/crystal-coverage:
+bin/crystal-coverage: $(shell find src -type f -name '*.cr')
 	$(SHARDS_BIN) build $(CRFLAGS)
 clean:
 	rm -f .bin/crystal-coverage .bin/crystal-coverage.dwarf
@@ -16,4 +16,4 @@ bin: build
 	cp ./bin/crystal-coverage $(SHARD_BIN)
 # test: build
 # 	$(CRYSTAL_BIN) spec
-# 	./bin/crystal-coverage 
+# 	./bin/crystal-coverage

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wait for the binary to compile. The binary will be build in `bin/crystal-coverag
 ## Usage
 
 ```
-crystal-coverage spec/myfile_spec1.cr spec/myfile_spec2.cr
+bin/crystal-coverage
 ```
 
 Coverage file will be recreated after your software run on `coverage/` folder.
@@ -60,7 +60,7 @@ software is executed without release flag.
 To test in `--release` mode, you can do:
 
 ```
-crystal-coverage src/main.cr -p | crystal eval --release
+bin/crystal-coverage -p | crystal eval --release
 ```
 
 ## How does it works?

--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,6 @@
-version: 1.0
+version: 2.0
 shards:
   ameba:
-    github: veelenga/ameba
-    version: 0.10.0
+    git: https://github.com/veelenga/ameba.git
+    version: 0.14.3
 

--- a/shard.lock
+++ b/shard.lock
@@ -1,6 +1,6 @@
 version: 2.0
 shards:
   ameba:
-    git: https://github.com/veelenga/ameba.git
+    git: https://github.com/crystal-ameba/ameba.git
     version: 0.14.3
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,11 +11,13 @@ targets:
   crystal-coverage:
     main: src/coverage/cli.cr
 
+crystal: ">= 1.0.0, < 2.0.0"
+
 scripts:
   postinstall: make bin
 
 development_dependencies:
   ameba:
-    github: veelenga/ameba
+    github: crystal-ameba/ameba
 
 license: MIT

--- a/src/coverage/inject/cli.cr
+++ b/src/coverage/inject/cli.cr
@@ -25,12 +25,12 @@ module Coverage
         end
       end
 
-      raise "You must choose a file to compile" unless filenames.any?
+      filenames = Dir["spec/**/*_spec.cr"] unless filenames.any?
 
       Coverage::SourceFile.outputter = "Coverage::Outputter::#{output_format.camelcase}"
 
       first = true
-      output = String::Builder.new(capacity: 2**18)
+      output = String::Builder.new
       filenames.each do |f|
         v = Coverage::SourceFile.new(path: f, source: ::File.read(f))
         output << v.to_covered_source

--- a/src/coverage/inject/cli.cr
+++ b/src/coverage/inject/cli.cr
@@ -1,4 +1,5 @@
 require "option_parser"
+
 # require "tempfile"
 
 module Coverage
@@ -8,11 +9,15 @@ module Coverage
       filenames = [] of String
       print_only = false
 
-      OptionParser.parse! do |parser|
-        parser.banner = "Usage: crystal-cover [options] <filename>"
+      OptionParser.parse do |parser|
+        parser.banner = "Usage: crystal-coverage [options] <filename>"
         parser.on("-o FORMAT", "--output-format=FORMAT", "The output format used (default: HtmlReport): HtmlReport, Coveralls ") { |f| output_format = f }
         parser.on("-p", "--print-only", "output the generated source code") { |_p| print_only = true }
         parser.on("--use-require=REQUIRE", "change the require of cover library in runtime") { |r| Coverage::SourceFile.use_require = r }
+        parser.on("-h", "--help", "Show this help") do
+          puts parser
+          exit
+        end
         parser.unknown_args do |args|
           args.each do
             filenames << ARGV.shift

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -81,7 +81,7 @@ class Coverage::SourceFile < Crystal::Visitor
 
   def to_covered_source
     if @enriched_source.nil?
-      io = String::Builder.new(capacity: 32_768)
+      io = String::Builder.new
 
       # call process to enrich AST before
       # injection of cover head dependencies
@@ -103,7 +103,7 @@ class Coverage::SourceFile < Crystal::Visitor
       file_list = @@require_expanders[expansion_id]
 
       if file_list.any?
-        io = String::Builder.new(capacity: (2 ** 20))
+        io = String::Builder.new
         file_list.each do |file|
           io << "#" << "require of `" << file.path
           io << "` from `" << self.path << ":#{file.required_at}" << "`" << "\n"
@@ -177,7 +177,7 @@ class Coverage::SourceFile < Crystal::Visitor
 
   private def force_inject_cover(node : Crystal::ASTNode, location = nil)
     location ||= node.location
-    return node if @already_covered_locations.includes?(location)
+    return node if @already_covered_locations.includes?(location) || @path.starts_with? "spec/"
     already_covered_locations << location
     Crystal::Expressions.from([inject_coverage_tracker(node), node].unsafe_as(Array(Crystal::ASTNode)))
   end

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -74,7 +74,9 @@ class Coverage::SourceFile < Crystal::Visitor
   # Inject in AST tree if required.
   def process
     unless @astree
-      @astree = Crystal::Parser.parse(self.source)
+      parser = Crystal::Parser.new(self.source)
+      parser.filename = File.expand_path(path, ".")
+      @astree = parser.parse
       astree.accept(self)
     end
   end

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -120,7 +120,7 @@ class Coverage::SourceFile < Crystal::Visitor
   end
 
   private def inject_location(file = @path, line = 0, column = 0)
-    %(#<loc:"#{file}",#{[line, 0].max},#{[column, 0].max}>)
+    %(#<loc:"#{File.expand_path(file, ".")}",#{[line, 0].max},#{[column, 0].max}>)
   end
 
   def self.prelude_operations

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -6,25 +6,6 @@ require "./extensions"
 require "./macro_utils"
 
 class Coverage::SourceFile < Crystal::Visitor
-  # List of keywords which are trouble with variable
-  # name. Some keywoards are not and won't be present in this
-  # list.
-  # Since this can break the code replacing the variable by a underscored
-  # version of it, and I'm not sure about this list, we will need to add/remove
-  # stuff to not break the code.
-  CRYSTAL_KEYWORDS = %w(
-    abstract do if nil? self unless
-    alias else of sizeof until
-    as elsif include struct when
-    as? end instance_sizeof pointerof super while
-    asm ensure is_a? private then with
-    begin enum lib protected true yield
-    break extend macro require
-    case false module rescue typeof
-    class for next return uninitialized
-    def fun nil select union
-  )
-
   class_getter file_list = [] of Coverage::SourceFile
   class_getter already_covered_file_name = Set(String).new
   class_getter! project_path : String
@@ -264,26 +245,11 @@ class Coverage::SourceFile < Crystal::Visitor
   end
 
   def visit(node : Crystal::Arg)
-    name = node.name
-    if CRYSTAL_KEYWORDS.includes?(name)
-      node.external_name = node.name = "_#{name}"
-    end
-
     true
   end
 
   # Placeholder for bug #XXX
   def visit(node : Crystal::Assign)
-    target = node.target
-    value = node.value
-
-    if target.is_a?(Crystal::InstanceVar) &&
-       value.is_a?(Crystal::Var)
-      if CRYSTAL_KEYWORDS.includes?(value.name)
-        value.name = "_#{value.name}"
-      end
-    end
-
     true
   end
 

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -315,7 +315,7 @@ class Coverage::SourceFile < Crystal::Visitor
     propagate_location_in_macro(node, node.location.not_nil!)
 
     node.then = force_inject_cover(node.then)
-    node.else = force_inject_cover(node.else)
+    node.else = force_inject_cover(node.else) unless node.cond == BoolLiteral.new(true)
     true
   end
 

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -144,12 +144,15 @@ class Coverage::SourceFile < Crystal::Visitor
 
   # Inject line tracer for easy debugging.
   # add `;` after the Coverage instrumentation
-  # to avoid some with macros
+  # to avoid some with macros. Be careful to only insert
+  # `;` if there is something else on the same line, or else
+  # it breaks parsing with expressions inside expressions.
   private def inject_line_traces(output)
     output.gsub(/\:\:Coverage\[([0-9]+),[ ]*([0-9]+)\](.*)/) do |_str, match|
       [
         "::Coverage[", match[1],
-        ", ", match[2], "]; ",
+        ", ", match[2], "]",
+        match[3].empty? ? " " : "; ",
         match[3],
         inject_location(@path, @lines[match[2].to_i] - 1),
       ].join("")

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -315,7 +315,7 @@ class Coverage::SourceFile < Crystal::Visitor
     propagate_location_in_macro(node, node.location.not_nil!)
 
     node.then = force_inject_cover(node.then)
-    node.else = force_inject_cover(node.else) unless node.cond == BoolLiteral.new(true)
+    node.else = force_inject_cover(node.else) unless node.cond == Crystal::BoolLiteral.new(true)
     true
   end
 

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -139,7 +139,7 @@ class Coverage::SourceFile < Crystal::Visitor
   end
 
   def self.final_operations
-    "\n::Coverage.get_results(#{@@outputter}.new)"
+    "\n Spec.after_suite { ::Coverage.get_results(#{@@outputter}.new) }"
   end
 
   # Inject line tracer for easy debugging.

--- a/src/coverage/inject/source_file.cr
+++ b/src/coverage/inject/source_file.cr
@@ -168,7 +168,7 @@ class Coverage::SourceFile < Crystal::Visitor
 
       n = Crystal::Call.new(Crystal::Global.new("::Coverage"), "[]",
         [Crystal::NumberLiteral.new(@id),
-         Crystal::NumberLiteral.new(lidx)].unsafe_as(Array(Crystal::ASTNode)))
+         Crystal::NumberLiteral.new(lidx)] of Crystal::ASTNode)
       n
     else
       node
@@ -179,7 +179,7 @@ class Coverage::SourceFile < Crystal::Visitor
     location ||= node.location
     return node if @already_covered_locations.includes?(location) || @path.starts_with? "spec/"
     already_covered_locations << location
-    Crystal::Expressions.from([inject_coverage_tracker(node), node].unsafe_as(Array(Crystal::ASTNode)))
+    Crystal::Expressions.from([inject_coverage_tracker(node), node] of Crystal::ASTNode)
   end
 
   def inject_cover(node : Crystal::ASTNode)

--- a/src/coverage/runtime/outputters/html_report.cr
+++ b/src/coverage/runtime/outputters/html_report.cr
@@ -1,6 +1,7 @@
 require "ecr"
 require "file_utils"
 require "html"
+require "../coverage"
 
 class Coverage::Outputter::HtmlReport < Coverage::Outputter
   struct CoverageReport
@@ -22,7 +23,7 @@ class Coverage::Outputter::HtmlReport < Coverage::Outputter
     end
 
     def percent_coverage_str
-      "#{(100*percent_coverage).round(2)}%"
+      "#{"%.2f" % (100*percent_coverage)}%"
     end
   end
 
@@ -71,8 +72,6 @@ class Coverage::Outputter::HtmlReport < Coverage::Outputter
   end
 
   def output(files : Array(Coverage::File))
-    puts "Generating coverage report, please wait..."
-
     system("rm -r coverage/")
 
     sum_lines = 0
@@ -107,14 +106,12 @@ class Coverage::Outputter::HtmlReport < Coverage::Outputter
       sum_covered += cr.covered_lines
 
       cr
+    end.select do |cr|
+      cr.relevant_lines > 0
     end
 
     # puts percent covered
-    if sum_lines == 0
-      puts "100% covered"
-    else
-      puts (100.0*(sum_covered / sum_lines.to_f)).round(2).to_s + "% covered"
-    end
+    print "\nLines #{sum_lines == 0 ? 100 : "%.2f" % (100 * sum_covered / sum_lines)}% covered"
 
     # Generate the code
     FileUtils.mkdir_p("coverage")

--- a/src/coverage/runtime/outputters/html_report.cr
+++ b/src/coverage/runtime/outputters/html_report.cr
@@ -72,7 +72,7 @@ class Coverage::Outputter::HtmlReport < Coverage::Outputter
   end
 
   def output(files : Array(Coverage::File))
-    system("rm -r coverage/")
+    system("rm -rf coverage/")
 
     sum_lines = 0
     sum_covered = 0

--- a/template/cover.html.ecr
+++ b/template/cover.html.ecr
@@ -94,15 +94,11 @@
     <hr>
     <table class="cover-table">
       <thead>
-        <th>Hitted lines</th>
-        <th>Relevant lines</th>
-        <th>Percentage</th>
+        <th>Lines</th>
       </thead>
       <tbody>
         <tr>
-          <td><%=@file.relevant_lines%></td>
-          <td><%=@file.covered_lines%></td>
-          <td class="low"><%=@file.percent_coverage_str%></td>
+          <td><%=@file.covered_lines%> / <%=@file.relevant_lines%> (<%=@file.percent_coverage_str%>)</td>
         </tr>
       </tbody>
     </table>

--- a/template/summary.html.ecr
+++ b/template/summary.html.ecr
@@ -32,24 +32,20 @@
   <table>
     <thead>
       <th>File</th>
-      <th>Relevant lines</th>
-      <th>Covered lines</th>
-      <th>Percentage covered</th>
+      <th>Lines</th>
     </thead>
     <tbody>
       <%- @covered_files.each do |file| -%>
       <tr>
         <td><a href="<%=file.md5%>.html"><%=file.filename%></a></td>
-        <td><%=file.relevant_lines%></td>
-        <td><%=file.covered_lines%></td>
-        <td><%=file.percent_coverage_str%></td>
+        <td><%=file.covered_lines%> / <%=file.relevant_lines%> (<%=file.percent_coverage_str%>)</td>
+        <td></td>
+        <td></td>
       </tr>
       <%- end -%>
       <tfoot>
         <th>TOTAL: </th>
-        <th><%= total_relevant %></th>
-        <th><%= total_covered %></th>
-        <th><%= total_percentage %></th>
+        <th><%= total_covered %> / <%= total_relevant %> (<%= total_percentage %>)</th>
       </tfoot>
     </tbody>
   </table>


### PR DESCRIPTION
This PR includes the following changes:

1. Make it build and collect coverage with Crystal 1.0.0+;
2. Add `--help` cli flag;
3. When run without specifying filenames, use the spec files inside the spec directory, the same behavior as `crystal spec`. It can now be used simply as `bin/crystal-coverage`.
4. Improve console output to better integrate with spec:

       $ ./bin/crystal-coverage
       ....
       Lines 81.93% covered

       Finished in 3.0 milliseconds
       4 examples, 0 failures, 0 errors, 0 pending

5. Modify HTML output to show line data as a single column. This change is in preparation to also collect branch and function information.